### PR TITLE
Fix cost basis when holdings drop below zero

### DIFF
--- a/backend/src/services/calculationService.js
+++ b/backend/src/services/calculationService.js
@@ -100,9 +100,11 @@ async function calculateAverageCostBasis() {
                         }
                     }
 
-                    currentTokens = 0; // Reset to 0, as we're "buying back" the missing amount
+                    // Buy the missing amount and immediately deduct it for the sale
                     costBasis += missingAmount * virtualBuyPrice;
-                    console.log(`[DEBUG] Injected virtual buy: missingAmount=${missingAmount}, virtualBuyPrice=${virtualBuyPrice}, costIncrease=${missingAmount * virtualBuyPrice}`);
+                    costBasis -= missingAmount * virtualBuyPrice;
+                    currentTokens = 0; // Reset to 0 after handling the oversell
+                    console.log(`[DEBUG] Injected virtual buy and sell: missingAmount=${missingAmount}, virtualBuyPrice=${virtualBuyPrice}`);
                 }
             }
             


### PR DESCRIPTION
## Summary
- ensure oversells don't inflate cost basis

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685deeccb82883328a6ad0854e7a0093